### PR TITLE
Reverses the subject and object of relationship in tooltip text

### DIFF
--- a/js/tripalD3.pedigree.js
+++ b/js/tripalD3.pedigree.js
@@ -418,9 +418,10 @@ tripalD3.pedigree = {
         // Add tooltips to the connecting lines to make sure it's
         // clear what the relationship is.
         var tooltips= d3.selectAll("path.tree-link")
+          .style('cursor', 'pointer')
           .append('title')
             .text(function(d,i) {
-              return d.target.relationship.subject + ' ' + d.target.relationship.type + ' ' + d.target.relationship.object;
+              return d.target.relationship.object + ' ' + d.target.relationship.type + ' ' + d.target.relationship.subject;
             });
 
         // Stash the old positions for transition.


### PR DESCRIPTION
This sorts out the backward placement of subject and object in the pedigree relationship as described in issue #19. To test, point tripald3 to branch backward-parents and refresh a stock page with pedigree diagram.

This PR also includes a line to change the pointer to cursor when hovering relationship link/line in the diagram and make the tooltip text appear as pointer switches.